### PR TITLE
Updates to create intensity rasters

### DIFF
--- a/arsf_dem/dem_lidar/__init__.py
+++ b/arsf_dem/dem_lidar/__init__.py
@@ -113,8 +113,13 @@ def _las_to_dem(in_las,out_raster,
                               bin_size=resolution,
                               projection=grass_location,
                               out_raster_format=out_raster_format)
+      elif demtype.upper() == 'INTENSITY':
+         grass_lidar.las_to_intensity(in_las, out_raster,
+                                      bin_size=resolution,
+                                      projection=grass_location,
+                                      out_raster_format=out_raster_format)
       else:
-         raise Exception('DEM Type not recognised - options are DSM or DTM')
+         raise Exception('DEM Type not recognised - options are DSM, DTM or Intensity')
 
    elif method.upper() == 'SPDLIB':
       # Create WKT file with projection
@@ -158,8 +163,10 @@ def _las_to_dem(in_las,out_raster,
          lastools_lidar.las_to_dsm(in_las, out_raster, flags=lastools_flags)
       elif demtype.upper() == 'DTM':
          lastools_lidar.las_to_dtm(in_las, out_raster, flags=lastools_flags)
+      elif demtype.upper() == 'INTENSITY':
+         lastools_lidar.las_to_intensity(in_las, out_raster, flags=lastools_flags)
       else:
-         raise Exception('DEM Type not recognised - options are DSM or DTM')
+         raise Exception('DEM Type not recognised - options are DSM, DTM or Intensity')
 
    elif method.upper() == 'FUSION':
       if demtype.upper() == 'DSM':
@@ -269,4 +276,38 @@ def las_to_dtm(in_las,out_raster,
                resolution=resolution,
                projection=projection,
                demtype='DTM',
+               method=method)
+
+def las_to_intensity(in_las,out_raster,
+                     resolution=dem_common.DEFAULT_LIDAR_RES_METRES,
+                     projection=None,
+                     method='GRASS'):
+   """
+   Helper function to generate an Intensity image from a LAS file.
+
+   Utility function to call las_to_intensity from grass_lidar or lastools_lidar
+
+   Arguments:
+
+   * in_las - Input LAS file.
+   * out_raster - Output raster
+   * resolution - Resolution to use for output raster.
+   * projection - Projection of input LAS files (and output raster) as GRASS location format (e.g., UTM30N).
+   * method - GRASS or LAStools
+
+   Returns:
+
+   None
+
+   Example::
+
+      from arsf_dem import dem_lidar
+      dem_lidar.las_to_intensity('in_las_file.las','out_intensity.tif')
+
+   """
+
+   _las_to_dem(in_las, out_raster,
+               resolution=resolution,
+               projection=projection,
+               demtype='INTENSITY',
                method=method)

--- a/arsf_dem/dem_lidar/__init__.py
+++ b/arsf_dem/dem_lidar/__init__.py
@@ -57,6 +57,7 @@ from .. import dem_common_functions
 from .. import grass_library
 
 LAS_TO_DEM_METHODS = ['GRASS','SPDLib','LAStools','FUSION','points2grid']
+LAS_TO_INTENSITY_METHODS = ['GRASS', 'LAStools']
 
 def _las_to_dem(in_las,out_raster,
                resolution=dem_common.DEFAULT_LIDAR_RES_METRES,

--- a/arsf_dem/dem_lidar/__init__.py
+++ b/arsf_dem/dem_lidar/__init__.py
@@ -106,19 +106,16 @@ def _las_to_dem(in_las,out_raster,
 
       if demtype.upper() == 'DSM':
          grass_lidar.las_to_dsm(in_las, out_raster,
-                              bin_size=resolution,
-                              projection=grass_location,
-                              out_raster_format=out_raster_format)
+                                bin_size=resolution,
+                                projection=grass_location)
       elif demtype.upper() == 'DTM':
          grass_lidar.las_to_dtm(in_las, out_raster,
-                              bin_size=resolution,
-                              projection=grass_location,
-                              out_raster_format=out_raster_format)
+                                bin_size=resolution,
+                                projection=grass_location)
       elif demtype.upper() == 'INTENSITY':
          grass_lidar.las_to_intensity(in_las, out_raster,
                                       bin_size=resolution,
-                                      projection=grass_location,
-                                      out_raster_format=out_raster_format)
+                                      projection=grass_location)
       else:
          raise Exception('DEM Type not recognised - options are DSM, DTM or Intensity')
 

--- a/arsf_dem/dem_lidar/grass_lidar.py
+++ b/arsf_dem/dem_lidar/grass_lidar.py
@@ -448,7 +448,7 @@ def las_to_intensity(in_las,out_raster=None,
                         las2txt_flags='-last_only',
                         projection=projection,
                         bin_size=bin_size,
-                        out_raster_format=dem_common.GDAL_OUTFILE_FORMAT,
-                        out_raster_type=dem_common.GDAL_OUTFILE_DATATYPE)
+                        out_raster_format=out_raster_format,
+                        out_raster_type=out_raster_type)
 
    return out_raster_name, grassdb_path

--- a/arsf_dem/dem_lidar/lastools_lidar.py
+++ b/arsf_dem/dem_lidar/lastools_lidar.py
@@ -327,8 +327,46 @@ def las_to_dtm(in_las, out_dtm, keep_las=False, flags=None):
       os.remove(lasfile_grd_tmp)
       return None
 
-def grass_proj_to_lastools_flag(in_grass_proj):
+def las_to_intensity(in_las, out_intensity, flags=None):
+   """
+   Create an Intensity image from a
+   from LAS file using the las2dem tool.
 
+   http://www.cs.unc.edu/~isenburg/lastools/download/las2dem_README.txt
+
+   Note: this tool requires a license.
+
+   Arguments:
+
+   * in_las - Input LAS file
+   * out_intensity - Output intensity image, format depends on extension.
+   * flags - List of additional flags for las2dem
+
+   Returns:
+
+   * None
+
+   """
+
+   if not _checkPaidLAStools():
+      raise Exception('Could not find LAStools, checked {}'.format(dem_common.LASTOOLS_NONFREE_BIN_PATH))
+
+   print('Creating Intensity image')
+   las2dem_cmd = [os.path.join(dem_common.LASTOOLS_NONFREE_BIN_PATH,
+                               'las2dem.exe')]
+   # Check for flags
+   if flags is not None:
+      las2dem_cmd += _check_flags(flags)
+
+   las2dem_cmd.extend(['-i',in_las, '-o',out_intensity, '-intensity'])
+
+   # Run directly through subprocess, as CallSubprocessOn
+   # raises exception under windows for unlicensed LAStools
+   print('Attempting to run command: ' + ' '.join(las2dem_cmd))
+   subprocess.check_output(las2dem_cmd)
+
+
+def grass_proj_to_lastools_flag(in_grass_proj):
    """
    Converts GRASS projection (e.g., UTM30N)
    into projection flags for LAStools

--- a/arsf_dem/dem_utilities.py
+++ b/arsf_dem/dem_utilities.py
@@ -46,6 +46,7 @@ import numpy
 from . import dem_common
 from . import dem_common_functions
 from . import grass_library
+from . import get_gdal_drivers
 
 # Import GRASS
 sys.path.append(dem_common.GRASS_PYTHON_LIB_PATH)
@@ -1227,23 +1228,12 @@ def get_gdal_type_from_path(file_name):
    if file_name is None:
       return dem_common.GDAL_OUTFILE_FORMAT
 
-   gdalStr = ''
+   gdal_str = ''
    extension = os.path.splitext(file_name)[-1].lower()
-   if extension == '.kea':
-      gdalStr = 'KEA'
-   elif extension == '.tif':
-      gdalStr = 'GTiff'
-   elif extension == '.jpg':
-      gdalStr = 'JPEG'
-   elif extension == '.img':
-      gdalStr = 'HFA'
-   elif extension == '.pix':
-      gdalStr = 'PCIDSK'
-   elif extension == '.asc' or extension == '.txt':
-      gdalStr = 'GRASSASCIIGrid'
-   else:
-      gdalStr = 'ENVI'
-   return gdalStr
+
+   gdal_str = get_gdal_drivers.GDALDrivers().get_driver_from_ext(extension)
+
+   return gdal_str
 
 def add_dem_metadata(dem_name, dem_source=None, dem_filename=None,
                                other_items=None):

--- a/arsf_dem/get_gdal_drivers.py
+++ b/arsf_dem/get_gdal_drivers.py
@@ -1,0 +1,162 @@
+"""
+get_gdal_drivers.py
+
+General library to get driver names and extensions for all supported
+GDAL drivers.
+
+Author: Dan Clewley (dac)
+Date: 07/05/2015
+
+License restrictions: None known. Uses GDAL (MIT/X license)
+
+Known issues: Some drivers must be used with creation options to get the desired
+output. For example .bil and .bsq both use the ENVI driver but must use creation
+options to specify the interleave.
+
+Available functions:
+
+* GDALDrivers().get_driver_from_ext - Get GDAL driver from extension
+* GDALDrivers().get_ext_from_driver - Get extension from GDAL driver name
+* GDALDrivers().get_creation_options_from_ext - Get GDAL creation options from extension
+* GDALDrivers().get_creation_options_from_driver - Get GDAL creation options driver name
+
+"""
+
+from osgeo import gdal
+
+#: List of Non-GDAL extensions (mostly for ENVI)
+NON_GDAL_DRIVER_FROM_EXT = {'bil' : 'ENVI',
+                            'bsq' : 'ENVI',
+                            'bip' : 'ENVI',
+                            'dem' : 'ENVI',
+                            'raw' : 'ENVI',
+                            'h5'  : 'HDF5',
+                            'tiff': 'GTiff'}
+
+#: Preferred creation options for GDAL
+GDAL_CREATION_OPTIONS = {'bil' : ['INTERLEAVE=BIL'],
+                         'bsq' : ['INTERLEAVE=BSQ'],
+                         'tif' : ['COMPRESS=LZW']}
+
+class GDALDrivers(object):
+   """
+   Class to get GDAL drivers or
+   extensions.
+
+   Gets list of all available GDAL drivers and adds some
+   additional extensions for existing drives (e.g., for ENVI)
+
+   Example usage::
+
+      import get_gdal_drivers
+      get_gdal_drivers.GDALDrivers().get_driver_from_ext('.tif')
+      get_gdal_drivers.GDALDrivers().get_ext_from_driver('GTiff')
+
+   """
+
+   def __init__(self):
+      # Set up two empty dictionaries
+      # One uses the extension as the key and one the driver
+      self.gdal_ext_from_driver = {}
+      self.gdal_driver_from_ext = {}
+
+      # Go through all drivers registered to GDAL
+      for driver_num in range(gdal.GetDriverCount()):
+         try:
+            driver = gdal.GetDriver(driver_num)
+            driver_ext = driver.GetMetadata()['DMD_EXTENSION']
+
+            # For ENVI use BSQ (will get this if we don't pass in creation options)
+            if driver.ShortName == 'ENVI':
+               driver_ext = 'bsq'
+
+            # If there is no extension, use the driver name in lower case
+            if driver_ext == '':
+               driver_ext = driver.ShortName.lower()
+
+            # Add to dictionaries
+            self.gdal_ext_from_driver[driver.ShortName] = driver_ext
+            self.gdal_driver_from_ext[driver_ext] = driver.ShortName
+
+         # If they don't have an extension specified - skip
+         except KeyError:
+            pass
+      # Add non-GDAL drivers
+      self.gdal_driver_from_ext.update(NON_GDAL_DRIVER_FROM_EXT)
+
+   def get_driver_from_ext(self, file_ext):
+      """
+      Get GDAL driver short name from file
+      extension.
+
+      :param file_ext: File extension (e.g., .bil)
+      :type file_ext: str
+
+      """
+      # Remove '.' if there is one before the extension.
+      file_ext = file_ext.lstrip('.')
+      try:
+         return self.gdal_driver_from_ext[file_ext]
+      except KeyError:
+         raise KeyError('The driver for file extension {} could not be found'.format(file_ext))
+
+   def get_ext_from_driver(self, driver_name):
+      """
+      Get file extension from GDAL short
+      driver name.
+
+      :param driver_name: Driver Name (e.g., GTiff)
+      :type driver_name: str
+
+      """
+      try:
+         return '.' + self.gdal_ext_from_driver[driver_name]
+      except KeyError:
+         raise KeyError('The extension for driver {} could not be found'.format(driver_name))
+
+   def get_creation_options_from_ext(self, file_ext):
+      """
+      Get preferred GDAL creation options from file
+      extension.
+
+      :param file_ext: File extension (e.g., .bil)
+      :type file_ext: str
+
+      """
+      # Remove '.' if there is one before the extension.
+      file_ext = file_ext.lstrip('.')
+      try:
+         return GDAL_CREATION_OPTIONS[file_ext]
+      except KeyError:
+         # If there are no creation options defined return an empty list
+         return []
+
+   def get_creation_options_from_driver(self, driver_name):
+      """
+      Get preferred GDAL creation options from file
+      extension.
+
+      :param driver_name: Driver Name (e.g., GTiff)
+      :type driver_name: str
+
+      """
+      file_ext = self.get_ext_from_driver(driver_name)
+      file_ext = file_ext.lstrip('.')
+      try:
+         return GDAL_CREATION_OPTIONS[file_ext]
+      except KeyError:
+         # If there are no creation options defined return an empty list
+         return []
+
+   def get_all_gdal_extensions(self):
+      """
+      Get all available GDAL extensions
+      """
+      return self.gdal_driver_from_ext.keys()
+
+   def get_all_gdal_drivers(self):
+      """
+      Get all available GDAL drivers
+      """
+      return self.gdal_ext_from_driver.keys()
+

--- a/doc/source/create_scripts_rst.py
+++ b/doc/source/create_scripts_rst.py
@@ -34,6 +34,7 @@ create_apl_dem_out = get_command_out(['create_apl_dem.py','-h'])
 create_dem_from_lidar_out = get_command_out(['create_dem_from_lidar.py','-h'])
 las_to_dsm_out = get_command_out(['las_to_dsm.py','-h'])
 las_to_dtm_out = get_command_out(['las_to_dtm.py','-h'])
+las_to_intensity_out = get_command_out(['las_to_intensity.py','-h'])
 mosaic_dem_tiles_out = get_command_out(['mosaic_dem_tiles.py','-h'])
 
 scripts_text = '''
@@ -73,6 +74,13 @@ las_to_dtm
 
 {}
 
+las_to_intensity
+------------------
+
+.. code-block:: bash
+
+{}
+
 mosaic_dem_tiles
 ------------------
 
@@ -84,6 +92,7 @@ mosaic_dem_tiles
            create_dem_from_lidar_out,
            las_to_dsm_out,
            las_to_dtm_out,
+           las_to_intensity_out,
            mosaic_dem_tiles_out)
 
 f = open(outfile,'w')

--- a/doc/source/scripts.rst
+++ b/doc/source/scripts.rst
@@ -71,7 +71,7 @@ create_apl_dem
    there is a problem finding hyperspectral navigation files the script will
    print a warning but continue and produce a DEM much larger than required.
    
-   'create_apl_dem' was created by ARSF-DAN at Plymouth Marine Laboraty (PML)
+   'create_apl_dem' was created by ARSF-DAN at Plymouth Marine Laboratory (PML)
    and is made available under the terms of the GPLv3 license.
    
       
@@ -155,9 +155,9 @@ create_dem_from_lidar
    finding hyperspectral navigation files will print warning but continue and produce
    a DEM much larger than is required. If the DEM is not required for APL you can use
    the flag '--lidar_bounds', which only uses the bounds of the lidar data, not navigation files
-   plus a buffer of 2000 m.
+   plus a buffer of 2000.0 m.
    
-   'create_dem_from_lidar' was created by ARSF-DAN at Plymouth Marine Laboraty (PML)
+   'create_dem_from_lidar' was created by ARSF-DAN at Plymouth Marine Laboratory (PML)
    and is made available under the terms of the GPLv3 license.
    
    positional arguments:
@@ -202,7 +202,7 @@ create_dem_from_lidar
                            to be used with APL and navigation data are available.
                            This is the default behaviour
      --lidar_bounds        If patching with another DEM, get extent from lidar
-                           data plus default buffer of 2000 m. If DEM is not
+                           data plus default buffer of 2000.0 m. If DEM is not
                            required to be used with APL this option is
                            recommended.
      --fill_lidar_nulls    Fill NULL values in LiDAR data using interpolation.
@@ -225,7 +225,7 @@ las_to_dsm
    
    Create a Digital Surface Model (DSM) from a LAS file.
    
-   'las_to_dsm' was created by ARSF-DAN at Plymouth Marine Laboraty (PML)
+   'las_to_dsm' was created by ARSF-DAN at Plymouth Marine Laboratory (PML)
    and is made available under the terms of the GPLv3 license.
    
    The programs used by las_to_dsm are available under a range of licenses, please
@@ -261,7 +261,7 @@ las_to_dtm
    
    Create a Digital Terrain Model (DTM) from a LAS file.
    
-   'las_to_dtm' was created by ARSF-DAN at Plymouth Marine Laboraty (PML)
+   'las_to_dtm' was created by ARSF-DAN at Plymouth Marine Laboratory (PML)
    and is made available under the terms of the GPLv3 license.
    
    The programs used by las_to_dtm are available under a range of licenses, please
@@ -282,6 +282,38 @@ las_to_dtm
                            Input projection (e.g., UTM30N)
      --method Method       Software package to use. Options are:
                            GRASS,SPDLib,LAStools,FUSION,points2grid
+   
+
+
+las_to_intensity
+------------------
+
+.. code-block:: bash
+
+   usage: las_to_intensity.py [-h] -o Out Intensity [-r Resolution]
+                              [--projection In Projection] [--method Method]
+                              lasfile
+   
+   Create an Intensity Raster from a LAS file.
+   
+   'las_to_intensity' was created by ARSF-DAN at Plymouth Marine Laboratory (PML)
+   and is made available under the terms of the GPLv3 license.
+   
+   The programs used by las_to_intensity are available under a range of licenses, please
+   consult their respective documentation for more details.
+   
+   positional arguments:
+     lasfile               Input LAS file
+   
+   optional arguments:
+     -h, --help            show this help message and exit
+     -o Out Intensity, --outintensity Out Intensity
+                           Output name for Intensity image
+     -r Resolution, --resolution Resolution
+                           Resolution for output image (default=2)
+     --projection In Projection
+                           Input projection (e.g., UTM30N)
+     --method Method       Software package to use. Options are: GRASS,LAStools
    
 
 

--- a/scripts/create_apl_dem.py
+++ b/scripts/create_apl_dem.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#Description: A script to create a DEM suitible for use in APL from ASTER, NextMap or another DEM mosaic. Uses arsf_dem library
+#Description: A script to create a DEM suitable for use in APL from ASTER, NextMap or another DEM mosaic. Uses arsf_dem library
 """
 Author: Dan Clewley (dac)
 
@@ -83,7 +83,7 @@ If the correct project path is not found or passed in, or for another reason
 there is a problem finding hyperspectral navigation files the script will
 print a warning but continue and produce a DEM much larger than required.
 
-'create_apl_dem' was created by ARSF-DAN at Plymouth Marine Laboraty (PML)
+'create_apl_dem' was created by ARSF-DAN at Plymouth Marine Laboratory (PML)
 and is made available under the terms of the GPLv3 license.
 
    '''.format(dem_common.WWGSG_FILE)

--- a/scripts/create_dem_from_lidar.py
+++ b/scripts/create_dem_from_lidar.py
@@ -58,7 +58,7 @@ a DEM much larger than is required. If the DEM is not required for APL you can u
 the flag '--lidar_bounds', which only uses the bounds of the lidar data, not navigation files
 plus a buffer of {1} m.
 
-'create_dem_from_lidar' was created by ARSF-DAN at Plymouth Marine Laboraty (PML)
+'create_dem_from_lidar' was created by ARSF-DAN at Plymouth Marine Laboratory (PML)
 and is made available under the terms of the GPLv3 license.
 
 '''.format(dem_common.DEFAULT_LIDAR_PROJECTION_GRASS, dem_common.DEFAULT_LIDAR_DEM_BUFFER['N'])

--- a/scripts/las_to_dsm.py
+++ b/scripts/las_to_dsm.py
@@ -30,7 +30,7 @@ DEBUG = False
 if __name__ == '__main__':
    description_str = '''Create a Digital Surface Model (DSM) from a LAS file.
 
-'las_to_dsm' was created by ARSF-DAN at Plymouth Marine Laboraty (PML)
+'las_to_dsm' was created by ARSF-DAN at Plymouth Marine Laboratory (PML)
 and is made available under the terms of the GPLv3 license.
 
 The programs used by las_to_dsm are available under a range of licenses, please

--- a/scripts/las_to_dtm.py
+++ b/scripts/las_to_dtm.py
@@ -31,7 +31,7 @@ DEBUG = False
 if __name__ == '__main__':
    description_str = '''Create a Digital Terrain Model (DTM) from a LAS file.
 
-'las_to_dtm' was created by ARSF-DAN at Plymouth Marine Laboraty (PML)
+'las_to_dtm' was created by ARSF-DAN at Plymouth Marine Laboratory (PML)
 and is made available under the terms of the GPLv3 license.
 
 The programs used by las_to_dtm are available under a range of licenses, please

--- a/scripts/las_to_intensity.bat
+++ b/scripts/las_to_intensity.bat
@@ -1,0 +1,2 @@
+@echo off
+python "%~dp0\las_to_intensity.py" %*

--- a/scripts/las_to_intensity.py
+++ b/scripts/las_to_intensity.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+#Description: A script to create an intensity raster from a LAS file.
+"""
+Author: Dan Clewley (dac)
+
+Created on: 19 January 2016
+
+"""
+# This file has been created by ARSF Data Analysis Node and
+# is licensed under the GPL v3 Licence. A copy of this
+# licence is available to download with this file.
+
+from __future__ import print_function # Import print function (so we can use Python 3 syntax with Python 2)
+import sys
+import argparse
+# Import DEM library
+try:
+   from arsf_dem import dem_common
+   from arsf_dem import dem_lidar
+   from arsf_dem import dem_common_functions
+except ImportError as err:
+   print("Could not import ARSF DEM library.", file=sys.stderr)
+   print(err, file=sys.stderr)
+   sys.exit(1)
+
+#: Debug mode
+DEBUG = False
+
+if __name__ == '__main__':
+   description_str = '''Create an Intensity Raster from a LAS file.
+
+'las_to_intensity' was created by ARSF-DAN at Plymouth Marine Laboratory (PML)
+and is made available under the terms of the GPLv3 license.
+
+The programs used by las_to_intensity are available under a range of licenses, please
+consult their respective documentation for more details.
+
+'''
+
+   try:
+      parser = argparse.ArgumentParser(description=description_str,formatter_class=argparse.RawDescriptionHelpFormatter)
+      parser.add_argument("lasfile", nargs=1,type=str, help="Input LAS file")
+      parser.add_argument('-o', '--outintensity',
+                          metavar ='Out Intensity',
+                          help ='Output name for Intensity image',
+                          required=True)
+      parser.add_argument('-r', '--resolution',
+                          metavar ='Resolution',
+                          help ='Resolution for output image (default={})'.format(dem_common.DEFAULT_LIDAR_RES_METRES),
+                          default=dem_common.DEFAULT_LIDAR_RES_METRES,
+                          required=False)
+      parser.add_argument('--projection',
+                          metavar ='In Projection',
+                          help ='Input projection (e.g., UTM30N)',
+                          default=None,
+                          required=False)
+      parser.add_argument('--method',
+                          metavar ='Method',
+                          help ='Software package to use. Options are:\n{}'.format(','.join(dem_lidar.LAS_TO_INTENSITY_METHODS)),
+                          default='GRASS',
+                          required=False)
+      args=parser.parse_args()
+
+      dem_lidar.las_to_intensity(args.lasfile[0], args.outintensity,
+                                 resolution=args.resolution,
+                                 projection=args.projection,
+                                 method=args.method)
+
+   except KeyboardInterrupt:
+      sys.exit(2)
+   except Exception as err:
+      if DEBUG:
+         raise
+      dem_common_functions.ERROR(err)
+      sys.exit(1)


### PR DESCRIPTION
- Added ability to create intensity rasters using the dem_lidar interface. Currently available using GRASS (was already implemented) and LAStools (paid version only). 
- Added 'get_gdal_drivers' so it can be used to get the GDAL driver name from a file extension. Replaces the existing function where some common extensions / drivers were hard coded.
